### PR TITLE
Improvement/Listen change event

### DIFF
--- a/src/jquery.submitable.js
+++ b/src/jquery.submitable.js
@@ -76,7 +76,7 @@
         bindEvents: function () {
             let plugin = this;
             $(document).ready(function () {
-                plugin.$element.on('input paste keyup', function () {
+                plugin.$element.on('input paste keyup change', function () {
                     plugin.changeDisabledButtons();
                 });
             });


### PR DESCRIPTION
Dans le core on fait
```
assignTo.brokkApi().onComplete = function () {
        $('#assign-to').val('').trigger('change');
    };
```
du coup ça reset l'input mais ne trigger pas submitable pour disabled le bouton.